### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#AngularJS Best Practices
+# AngularJS Best Practices
 
-##Feature Driven Development
+## Feature Driven Development
 See: http://www.johnpapa.net/angular-growth-structure/
 
 Feature driven development is more about how you organise and structure your application than how you code the functionality. Rather than produce 1 large complicated app you create discreet pieces and couple them together. 
 
-###By type - No
+### By type - No
 Files organised by type means having your controllers, services, 
 filters, directives, views etc. placed in their respective folders. 
 Nothing is discrete, development and testing is done in large 
@@ -21,7 +21,7 @@ blocks. Large applications quickly become overly complex.
     |- services
     |--- auth.svc.js
 
-###By Feature - Yes
+### By Feature - Yes
 The application is organised by the self-contained features that it
 requires. Each feature can be plugged into or out of the application
 with relative ease. It is not baked directly into the application’s
@@ -47,7 +47,7 @@ scope of each feature.
 for an example of how to organise your application and what each 
 directory is used for.**
 
-##Module Declaration
+## Module Declaration
 Modules should be declared using the global `angular` variable like so:
 
     // app module
@@ -63,14 +63,14 @@ Modules should be declared using the global `angular` variable like so:
 - Modules can be placed into different files
 - You can use the function-form of `use strict;`
 
-##Dependency Injection
+## Dependency Injection
 See: http://docs.angularjs.org/guide/dev_guide.services.managing_dependencies
 
 There are two types of dependencies you can include in your modules 
 and controllers. The first is listing your required modules and the
 second is injecting services into your controllers.
 
-###Requiring modules
+### Requiring modules
 
     angular.module('demo', [
                    'demo.features.login
@@ -80,20 +80,20 @@ This is a fairly standard process of how we require modules in AngularJS.
 Naming conventions are covered in the next section but you can see here 
 that required modules should be grouped by feature.
 
-###Injecting dependencies
+### Injecting dependencies
 
 Should be done explicity to prevent errors during minification and disjointed
 dependencies within your code.
 
     .controller('homeCtrl', ['$scope', '$state', function ($scope, $state) { }])
 
-##Naming Conventions
+## Naming Conventions
 It is important to provide distinct names to components of your 
 application. This mitigates the possibility that the angular source,
 3rd party libraries and shared components will have clashing module 
 names, giving unexpected results.
 
-###Prefixing
+### Prefixing
 All components (directives, controllers, services) must be
 prefixed with an identifier that is relevant to their scope:
 
@@ -103,7 +103,7 @@ Wizards for example.
 Grumpy Wizards built a todo list app for example.
 - *controllers do not need to be prefixed*
 
-###Postfixing
+### Postfixing
 The following component types should be postfixed as per the examples below:
 
 - Controllers: MarkdownCtrl
@@ -111,12 +111,12 @@ The following component types should be postfixed as per the examples below:
 - Filters: wizMarkdownFltr
 - Directives: do not require postfixing wizMarkdown > becomes `wiz-markdown` in markup
 
-###Capitalisation
+### Capitalisation
 Controllers are considered classes and as such they should have a leading
 capital letter: MarkdownCtrl, all other components should start with lower
 case e.g. wizMarkdown.
 
-###Modules
+### Modules
 Module namespacing format should following this pattern:
 
     <application>.<[api,component,feature,service]>.<name>
@@ -127,7 +127,7 @@ Examples:
 - reader.todo.api.email
 - users.feature.about
 
-###Filenames
+### Filenames
 To aid readability in the solution the type of component should be 
 appended to each file name, for example:
 
@@ -141,7 +141,7 @@ appended to each file name, for example:
 - dashboard.spec.conf.js – unit tests config
 - dashboard.feature – cucumber specificiation for testing
 
-##HTML Templates and Logic
+## HTML Templates and Logic
 See: http://docs.angularjs.org/guide/templates
 
 > An Angular template is the declarative specification that, 
@@ -174,13 +174,13 @@ would create additional overhead if we were to update that
 condition. By encapsulating the logic in a property or method 
 it provides both semantically correct mark-up and re-usability.
 
-##Directives
+## Directives
 See: http://docs.angularjs.org/guide/directive
 
 Directives are a way to attach a specified behaviour to a DOM 
 element or even to transform an element and its children.
 
-###Attributes
+### Attributes
 When you are decorating an existing element with new
 functionality, directives should be applied as attributes.
 
@@ -194,7 +194,7 @@ These directives should be developed in a generic way, with
 minimal understanding of the element content and can be used across 
 an application.
 
-###Elements
+### Elements
 When creating self-contained components, you should use the element 
 notation. This allows us to describe functionality in templates by 
 applying directives as a **domain specific language**.
@@ -210,13 +210,13 @@ can simply switch functionality on or off by adding or removing the element.
 
 Element directives should be placed alongside their corresponding feature. 
 
-##Filters
+## Filters
 See: http://docs.angularjs.org/guide/filter
 
 Filters should be organised in accordance to their parent features, 
 unless they are designed to provide commonly accessible functionality.
 
-###Performance of filters
+### Performance of filters
 Angular continuously conducts “dirty-checking”, in essence it is 
 looking for changes to values over and over again and raising events 
 for $watch and $filter to hook into. If you place a filter on your 
@@ -231,7 +231,7 @@ within the repeater’s array.
 
 If possible, you should apply filters to your data before binding to your view
 
-##Services
+## Services
 Services are responsible for the business logic in your application.
 
 UI logic, when to disable a button for example, should not be 
@@ -240,10 +240,10 @@ carried out in a service.
 **See the [ngTemplate project](http://grumpywizards.com/ngtemplate) for
 further info on where to place your business logic.**
 
-##Routers
+## Routers
 See: https://github.com/angular-ui/ui-router
 
-###AngularUI Router
+### AngularUI Router
 All routing should be conducted using AngularUI Router. AngularUI 
 Router is an external plugin used to convert your application into
 a state machine. ngRoute uses the URL to drive navigation. uiRouter 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
